### PR TITLE
Fixed the permission for the TV folder

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -3,4 +3,5 @@
 # permissions
 chown -R abc:abc \
 	/app \
-	/config
+	/config \
+	/tv


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
This fixes the permissions for the "tv" folder which was created by the root user. This causes errors when we use a different user than root in the configuration.
