### PR TITLE
add python3 requirements for app and build rar from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,41 @@
 FROM ghcr.io/linuxserver/baseimage-alpine:3.15
 
 # set version label
+ARG UNRAR_VERSION=6.1.4
 ARG BUILD_DATE
 ARG VERSION
 ARG MEDUSA_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs,aptalca"
+LABEL maintainer="aptalca"
 
 ENV LANG='en_US.UTF-8'
 
 RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --upgrade --virtual=build-dependencies \
+    make \
+    g++ \
+    gcc && \
   echo "**** install packages ****" && \
   apk add -U --update --no-cache \
     curl \
     mediainfo \
+    py3-chardet \
+    py3-idna \
+    py3-openssl \
+    py3-urllib3 \
     python3 && \
-  apk add -U --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main \
-    unrar && \
+  echo "**** install unrar from source ****" && \
+  mkdir /tmp/unrar && \
+  curl -o \
+    /tmp/unrar.tar.gz -L \
+    "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \  
+  tar xf \
+    /tmp/unrar.tar.gz -C \
+    /tmp/unrar --strip-components=1 && \
+  cd /tmp/unrar && \
+  make && \
+  install -v -m755 unrar /usr/bin && \
   echo "**** install app ****" && \
   if [ -z ${MEDUSA_RELEASE+x} ]; then \
     MEDUSA_RELEASE=$(curl -sX GET "https://api.github.com/repos/pymedusa/Medusa/releases/latest" \
@@ -30,8 +49,11 @@ RUN \
   tar xf /tmp/medusa.tar.gz -C \
     /app/medusa --strip-components=1 && \
   echo "**** clean up ****" && \
+  apk del --purge \
+    build-dependencies && \
   rm -rf \
-      /tmp/*
+    /root/.cache \
+    /tmp/*
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,22 +1,41 @@
 FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.15
 
 # set version label
+ARG UNRAR_VERSION=6.1.4
 ARG BUILD_DATE
 ARG VERSION
 ARG MEDUSA_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs,aptalca"
+LABEL maintainer="aptalca"
 
 ENV LANG='en_US.UTF-8'
 
 RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --upgrade --virtual=build-dependencies \
+    make \
+    g++ \
+    gcc && \
   echo "**** install packages ****" && \
   apk add -U --update --no-cache \
     curl \
     mediainfo \
+    py3-chardet \
+    py3-idna \
+    py3-openssl \
+    py3-urllib3 \
     python3 && \
-  apk add -U --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main \
-    unrar && \
+  echo "**** install unrar from source ****" && \
+  mkdir /tmp/unrar && \
+  curl -o \
+    /tmp/unrar.tar.gz -L \
+    "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \  
+  tar xf \
+    /tmp/unrar.tar.gz -C \
+    /tmp/unrar --strip-components=1 && \
+  cd /tmp/unrar && \
+  make && \
+  install -v -m755 unrar /usr/bin && \
   echo "**** install app ****" && \
   if [ -z ${MEDUSA_RELEASE+x} ]; then \
     MEDUSA_RELEASE=$(curl -sX GET "https://api.github.com/repos/pymedusa/Medusa/releases/latest" \
@@ -30,8 +49,11 @@ RUN \
   tar xf /tmp/medusa.tar.gz -C \
     /app/medusa --strip-components=1 && \
   echo "**** clean up ****" && \
+  apk del --purge \
+    build-dependencies && \
   rm -rf \
-      /tmp/*
+    /root/.cache \
+    /tmp/*
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,22 +1,41 @@
 FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.15
 
 # set version label
+ARG UNRAR_VERSION=6.1.4
 ARG BUILD_DATE
 ARG VERSION
 ARG MEDUSA_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
-LABEL maintainer="sparklyballs,aptalca"
+LABEL maintainer="aptalca"
 
 ENV LANG='en_US.UTF-8'
 
 RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --upgrade --virtual=build-dependencies \
+    make \
+    g++ \
+    gcc && \
   echo "**** install packages ****" && \
   apk add -U --update --no-cache \
     curl \
     mediainfo \
+    py3-chardet \
+    py3-idna \
+    py3-openssl \
+    py3-urllib3 \
     python3 && \
-  apk add -U --update --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.14/main \
-    unrar && \
+  echo "**** install unrar from source ****" && \
+  mkdir /tmp/unrar && \
+  curl -o \
+    /tmp/unrar.tar.gz -L \
+    "https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz" && \  
+  tar xf \
+    /tmp/unrar.tar.gz -C \
+    /tmp/unrar --strip-components=1 && \
+  cd /tmp/unrar && \
+  make && \
+  install -v -m755 unrar /usr/bin && \
   echo "**** install app ****" && \
   if [ -z ${MEDUSA_RELEASE+x} ]; then \
     MEDUSA_RELEASE=$(curl -sX GET "https://api.github.com/repos/pymedusa/Medusa/releases/latest" \
@@ -30,8 +49,11 @@ RUN \
   tar xf /tmp/medusa.tar.gz -C \
     /app/medusa --strip-components=1 && \
   echo "**** clean up ****" && \
+  apk del --purge \
+    build-dependencies && \
   rm -rf \
-      /tmp/*
+    /root/.cache \
+    /tmp/*
 
 # copy local files
 COPY root/ /

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **28.02.22:** - Install python3 requirements for app.
 * **19.01.22:** - Rebasing to alpine 3.15.
 * **01.06.20:** - Rebasing to alpine 3.12.
 * **19.12.19:** - Rebasing to alpine 3.11.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -34,6 +34,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.02.22:", desc: "Install python3 requirements for app." }
   - { date: "19.01.22:", desc: "Rebasing to alpine 3.15." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }


### PR DESCRIPTION
closes #34

depends pulled from here: 
https://github.com/pymedusa/Medusa/blob/55cecb9e821fb15f20efe75b0f59d13e896e1d87/ext/requests/help.py#L9-L11

These are in the default python 3.7 image used upstream which is why they expect them to be there. 

Also install unrar from source instead of from 3.14 repos.